### PR TITLE
Make config files optional in docker-dev

### DIFF
--- a/docker-dev.Dockerfile
+++ b/docker-dev.Dockerfile
@@ -2,10 +2,7 @@ FROM python:3
 
 WORKDIR /usr/src/app
 
-COPY requirements.txt ./
+COPY requirements.txt .env* config.ini* ./
 RUN pip install --no-cache-dir -r requirements.txt
-
-COPY *.env ./
-COPY *.ini ./
 
 CMD [ "uvicorn", "filmio.main:app", "--reload", "--host", "0.0.0.0" ]


### PR DESCRIPTION
Now docker won't throw an error if you don't have a `.env` or `config.ini`
file. I merged 3 copy instructions into one.